### PR TITLE
fix: GitHubオーナー名をyone-kに修正

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,7 @@ archives:
 
 release:
   github:
-    owner: yone
+    owner: yone-k
     name: cc-subagent-viewer
   draft: false
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ npx cc-subagent-viewer
 Go 1.25 以上が必要です。
 
 ```bash
-go install github.com/yone/cc-subagent-viewer@latest
+go install github.com/yone-k/cc-subagent-viewer@latest
 ```
 
 または、リポジトリをクローンしてビルド:
 
 ```bash
-git clone https://github.com/yone/cc-subagent-viewer.git
+git clone https://github.com/yone-k/cc-subagent-viewer.git
 cd cc-subagent-viewer
 go build -o cc-subagent-viewer .
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yone/cc-subagent-viewer
+module github.com/yone-k/cc-subagent-viewer
 
 go 1.25.0
 

--- a/internal/tui/agentview.go
+++ b/internal/tui/agentview.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 // AgentViewMode represents the current view mode within the Agents tab.

--- a/internal/tui/agentview_test.go
+++ b/internal/tui/agentview_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 // TestAgentView_EmptyState verifies that View() contains "サブエージェントなし" when no agents exist.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 // AppState represents the application state.

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 func TestAppModel_InitialState(t *testing.T) {

--- a/internal/tui/conversationview.go
+++ b/internal/tui/conversationview.go
@@ -8,7 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 // renderedBlock is a pre-rendered block for display in the conversation view.

--- a/internal/tui/conversationview_test.go
+++ b/internal/tui/conversationview_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 // helper: create a ConversationViewModel with reasonable size and test entries.

--- a/internal/tui/logview.go
+++ b/internal/tui/logview.go
@@ -8,8 +8,8 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 const maxLogEntries = 10000

--- a/internal/tui/logview_test.go
+++ b/internal/tui/logview_test.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 func makeLogEntry(level claude.LogLevel, message string) claude.LogEntry {

--- a/internal/tui/selector.go
+++ b/internal/tui/selector.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 // SelectorFilterMode controls which sessions are displayed in the selector.

--- a/internal/tui/selector_test.go
+++ b/internal/tui/selector_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 func TestSelectorModel_Init(t *testing.T) {

--- a/internal/tui/statsview.go
+++ b/internal/tui/statsview.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 // StatsUpdatedMsg is sent when stats data is available.

--- a/internal/tui/statsview_test.go
+++ b/internal/tui/statsview_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 // StatsUpdatedMsg is sent when stats are available.

--- a/internal/tui/taskview.go
+++ b/internal/tui/taskview.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 const maxProgressBarWidth = 40

--- a/internal/tui/taskview_test.go
+++ b/internal/tui/taskview_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/watcher"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/watcher"
 )
 
 func TestTaskView_UpdateWithTasks(t *testing.T) {

--- a/internal/watcher/conversationwatcher.go
+++ b/internal/watcher/conversationwatcher.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 const conversationPollInterval = 1 * time.Second

--- a/internal/watcher/conversationwatcher_test.go
+++ b/internal/watcher/conversationwatcher_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 func writeAgentFile(t *testing.T, dir, filename, content string) {

--- a/internal/watcher/logwatcher.go
+++ b/internal/watcher/logwatcher.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 const logPollInterval = 500 * time.Millisecond

--- a/internal/watcher/taskwatcher.go
+++ b/internal/watcher/taskwatcher.go
@@ -6,7 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/fsnotify/fsnotify"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 // TaskWatcher watches a tasks directory for changes.

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -1,7 +1,7 @@
 package watcher
 
 import (
-	"github.com/yone/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
 )
 
 // TasksUpdatedMsg is sent when all tasks are loaded/reloaded.

--- a/main.go
+++ b/main.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/yone/cc-subagent-viewer/internal/claude"
-	"github.com/yone/cc-subagent-viewer/internal/tui"
+	"github.com/yone-k/cc-subagent-viewer/internal/claude"
+	"github.com/yone-k/cc-subagent-viewer/internal/tui"
 )
 
 type runMode int

--- a/npm/cc-subagent-viewer/package.json
+++ b/npm/cc-subagent-viewer/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yone/cc-subagent-viewer.git"
+    "url": "https://github.com/yone-k/cc-subagent-viewer.git"
   },
   "bin": {
     "cc-subagent-viewer": "./bin/cc-subagent-viewer"

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yone/cc-subagent-viewer.git"
+    "url": "https://github.com/yone-k/cc-subagent-viewer.git"
   }
 }

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yone/cc-subagent-viewer.git"
+    "url": "https://github.com/yone-k/cc-subagent-viewer.git"
   }
 }

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yone/cc-subagent-viewer.git"
+    "url": "https://github.com/yone-k/cc-subagent-viewer.git"
   }
 }

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/yone/cc-subagent-viewer.git"
+    "url": "https://github.com/yone-k/cc-subagent-viewer.git"
   }
 }


### PR DESCRIPTION
## Summary

- GoReleaserのrelease設定でowner名が `yone` になっておりGitHub Releases作成が404で失敗していた
- `yone` → `yone-k` に全ファイルで修正
  - `.goreleaser.yaml` のrelease.github.owner
  - Goモジュール名・全importパス
  - npmパッケージのrepository URL
  - READMEのgo install / git clone URL

## Test plan

- [ ] GitHub Actionsでテストが通ること
- [ ] マージ後にv0.1.0タグを再作成し、GoReleaserリリースが成功すること