### PR TITLE
feat: 各ビューにページスクロール機能を追加

### DIFF
--- a/internal/tui/agentview.go
+++ b/internal/tui/agentview.go
@@ -55,6 +55,15 @@ func (m AgentViewModel) viewHeight() int {
 	return h
 }
 
+// listPageSize returns the number of agents per page scroll (1 agent = 3 lines).
+func (m AgentViewModel) listPageSize() int {
+	ps := m.viewHeight() / 3
+	if ps < 1 {
+		ps = 1
+	}
+	return ps
+}
+
 // clampScroll adjusts scrollOffset so the selected agent is always visible.
 func (m AgentViewModel) clampScroll() AgentViewModel {
 	viewHeight := m.viewHeight()
@@ -144,6 +153,18 @@ func (m AgentViewModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.conversationView.SetData(agent.AgentID, entries, info)
 				m.conversationView.SetSize(m.width, m.height)
 				m.mode = AgentViewModeConversation
+			}
+		case "pgdown":
+			if len(m.agents) > 0 {
+				m.agentSelected += m.listPageSize()
+				if m.agentSelected >= len(m.agents) {
+					m.agentSelected = len(m.agents) - 1
+				}
+			}
+		case "pgup":
+			m.agentSelected -= m.listPageSize()
+			if m.agentSelected < 0 {
+				m.agentSelected = 0
 			}
 		}
 		m = m.clampScroll()

--- a/internal/tui/agentview_test.go
+++ b/internal/tui/agentview_test.go
@@ -219,3 +219,194 @@ func TestAgentView_ScrollFollowsSelection(t *testing.T) {
 		t.Errorf("scrollOffset = %d, want 0", m.scrollOffset)
 	}
 }
+
+// pgUpKey, pgDownKey are declared in conversationview_test.go (same package)
+
+func TestAgentView_PageDown(t *testing.T) {
+	m := NewAgentViewModel()
+	m.SetSize(80, 11) // viewHeight = 11-2 = 9, pageSize = 9/3 = 3
+
+	// Given: 10 agents, agentSelected at 0
+	agents := make([]claude.SubagentInfo, 10)
+	for i := range agents {
+		agents[i] = claude.SubagentInfo{
+			AgentID: fmt.Sprintf("agent-%d", i+1),
+			Slug:    fmt.Sprintf("agent-%d", i+1),
+			Prompt:  fmt.Sprintf("Prompt for agent %d", i+1),
+		}
+	}
+	updated, _ := m.Update(watcher.SubagentsDiscoveredMsg{Agents: agents})
+	m = updated.(AgentViewModel)
+
+	// When: pgdown is pressed
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = updated.(AgentViewModel)
+
+	// Then: agentSelected moves by pageSize (3)
+	if m.agentSelected != 3 {
+		t.Errorf("after pgdown, agentSelected = %d, want 3", m.agentSelected)
+	}
+}
+
+func TestAgentView_PageUp(t *testing.T) {
+	m := NewAgentViewModel()
+	m.SetSize(80, 11) // viewHeight = 11-2 = 9, pageSize = 9/3 = 3
+
+	// Given: 10 agents, agentSelected at index 6
+	agents := make([]claude.SubagentInfo, 10)
+	for i := range agents {
+		agents[i] = claude.SubagentInfo{
+			AgentID: fmt.Sprintf("agent-%d", i+1),
+			Slug:    fmt.Sprintf("agent-%d", i+1),
+			Prompt:  fmt.Sprintf("Prompt for agent %d", i+1),
+		}
+	}
+	updated, _ := m.Update(watcher.SubagentsDiscoveredMsg{Agents: agents})
+	m = updated.(AgentViewModel)
+
+	// Move to index 6
+	for i := 0; i < 6; i++ {
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		m = updated.(AgentViewModel)
+	}
+	if m.agentSelected != 6 {
+		t.Fatalf("setup: agentSelected = %d, want 6", m.agentSelected)
+	}
+
+	// When: pgup is pressed
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = updated.(AgentViewModel)
+
+	// Then: agentSelected moves up by pageSize (3)
+	if m.agentSelected != 3 {
+		t.Errorf("after pgup, agentSelected = %d, want 3", m.agentSelected)
+	}
+}
+
+func TestAgentView_PageDown_ClampsAtEnd(t *testing.T) {
+	m := NewAgentViewModel()
+	m.SetSize(80, 11) // viewHeight = 11-2 = 9, pageSize = 9/3 = 3
+
+	// Given: 5 agents, agentSelected at index 3
+	agents := make([]claude.SubagentInfo, 5)
+	for i := range agents {
+		agents[i] = claude.SubagentInfo{
+			AgentID: fmt.Sprintf("agent-%d", i+1),
+			Slug:    fmt.Sprintf("agent-%d", i+1),
+			Prompt:  fmt.Sprintf("Prompt for agent %d", i+1),
+		}
+	}
+	updated, _ := m.Update(watcher.SubagentsDiscoveredMsg{Agents: agents})
+	m = updated.(AgentViewModel)
+
+	// Move to index 3
+	for i := 0; i < 3; i++ {
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		m = updated.(AgentViewModel)
+	}
+
+	// When: pgdown is pressed (3 + 3 = 6, but max is 4)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = updated.(AgentViewModel)
+
+	// Then: agentSelected clamped to last item (index 4)
+	if m.agentSelected != 4 {
+		t.Errorf("after pgdown near end, agentSelected = %d, want 4", m.agentSelected)
+	}
+}
+
+func TestAgentView_PageUp_ClampsAtStart(t *testing.T) {
+	m := NewAgentViewModel()
+	m.SetSize(80, 11) // viewHeight = 11-2 = 9, pageSize = 9/3 = 3
+
+	// Given: 10 agents, agentSelected at index 2
+	agents := make([]claude.SubagentInfo, 10)
+	for i := range agents {
+		agents[i] = claude.SubagentInfo{
+			AgentID: fmt.Sprintf("agent-%d", i+1),
+			Slug:    fmt.Sprintf("agent-%d", i+1),
+			Prompt:  fmt.Sprintf("Prompt for agent %d", i+1),
+		}
+	}
+	updated, _ := m.Update(watcher.SubagentsDiscoveredMsg{Agents: agents})
+	m = updated.(AgentViewModel)
+
+	// Move to index 2
+	for i := 0; i < 2; i++ {
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+		m = updated.(AgentViewModel)
+	}
+
+	// When: pgup is pressed (2 - 3 = -1, should clamp to 0)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = updated.(AgentViewModel)
+
+	// Then: agentSelected clamped to 0
+	if m.agentSelected != 0 {
+		t.Errorf("after pgup near start, agentSelected = %d, want 0", m.agentSelected)
+	}
+}
+
+func TestAgentView_PageScroll_FewerAgentsThanPageSize(t *testing.T) {
+	m := NewAgentViewModel()
+	m.SetSize(80, 20) // viewHeight = 20-2 = 18, pageSize = 18/3 = 6
+
+	// Given: only 2 agents (fewer than pageSize of 6)
+	agents := make([]claude.SubagentInfo, 2)
+	for i := range agents {
+		agents[i] = claude.SubagentInfo{
+			AgentID: fmt.Sprintf("agent-%d", i+1),
+			Slug:    fmt.Sprintf("agent-%d", i+1),
+			Prompt:  fmt.Sprintf("Prompt for agent %d", i+1),
+		}
+	}
+	updated, _ := m.Update(watcher.SubagentsDiscoveredMsg{Agents: agents})
+	m = updated.(AgentViewModel)
+
+	// When: pgdown is pressed
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = updated.(AgentViewModel)
+
+	// Then: agentSelected moves to last item (index 1)
+	if m.agentSelected != 1 {
+		t.Errorf("pgdown with few agents, agentSelected = %d, want 1", m.agentSelected)
+	}
+
+	// When: pgup is pressed
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = updated.(AgentViewModel)
+
+	// Then: agentSelected moves back to 0
+	if m.agentSelected != 0 {
+		t.Errorf("pgup with few agents, agentSelected = %d, want 0", m.agentSelected)
+	}
+}
+
+func TestAgentView_PageScroll_OnlyInListMode(t *testing.T) {
+	m := NewAgentViewModel()
+	m.SetSize(80, 11)
+
+	// Given: agents and in conversation mode
+	agents := []claude.SubagentInfo{
+		{AgentID: "a1", Slug: "test-agent", Prompt: "test prompt", EntryCount: 3},
+	}
+	updated, _ := m.Update(watcher.SubagentsDiscoveredMsg{Agents: agents})
+	m = updated.(AgentViewModel)
+
+	// Enter conversation mode
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(AgentViewModel)
+	if m.Mode() != AgentViewModeConversation {
+		t.Fatalf("expected AgentViewModeConversation, got %d", m.Mode())
+	}
+
+	// When: pgdown is pressed in conversation mode
+	// Then: it should not affect agentSelected (it's delegated to conversation view)
+	prevSelected := m.agentSelected
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = updated.(AgentViewModel)
+
+	if m.agentSelected != prevSelected {
+		t.Errorf("pgdown in conversation mode should not change agentSelected, was %d, got %d", prevSelected, m.agentSelected)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -304,17 +304,19 @@ func (m *AppModel) footerHelp() string {
 	var keys string
 
 	switch m.tabs.Active {
+	case 0:
+		keys = "j/k: スクロール  pgup/pgdn: ページ送り  1-4: タブ切替  q: 終了"
 	case 1:
 		switch m.agentView.Mode() {
 		case AgentViewModeList:
-			keys = "enter: 会話表示  1-4: タブ切替  q: 終了"
+			keys = "j/k: スクロール  pgup/pgdn: ページ送り  enter: 会話表示  1-4: タブ切替  q: 終了"
 		case AgentViewModeConversation:
-			keys = "j/k: スクロール  shift+←→: フィルタ選択  enter: フィルタ切替  esc: 戻る  q: 終了"
+			keys = "j/k: スクロール  pgup/pgdn: ページ送り  shift+←→: フィルタ選択  enter: フィルタ切替  esc: 戻る  q: 終了"
 		default:
 			keys = "1-4/←→: タブ切替  q: 終了"
 		}
 	case 2:
-		keys = "j/k: スクロール  shift+←→: フィルタ選択  enter: フィルタ切替  /: 検索  q: 終了"
+		keys = "j/k: スクロール  pgup/pgdn: ページ送り  shift+←→: フィルタ選択  enter: フィルタ切替  /: 検索  q: 終了"
 	default:
 		keys = "1-4/←→: タブ切替  q: 終了"
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -307,6 +307,76 @@ func TestAppModel_ShiftArrowDelegatedToLogView(t *testing.T) {
 	}
 }
 
+func TestAppModel_FooterHelp(t *testing.T) {
+	tests := []struct {
+		name         string
+		tab          int
+		agentMode    AgentViewMode
+		wantContains []string
+	}{
+		{
+			name: "Tab0_Task",
+			tab:  0,
+			wantContains: []string{
+				"pgup/pgdn",
+				"j/k: スクロール",
+				"1-4: タブ切替",
+				"q: 終了",
+			},
+		},
+		{
+			name:      "Tab1_AgentList",
+			tab:       1,
+			agentMode: AgentViewModeList,
+			wantContains: []string{
+				"pgup/pgdn",
+				"j/k: スクロール",
+				"enter: 会話表示",
+			},
+		},
+		{
+			name:      "Tab1_AgentConversation",
+			tab:       1,
+			agentMode: AgentViewModeConversation,
+			wantContains: []string{
+				"pgup/pgdn",
+				"j/k: スクロール",
+				"esc: 戻る",
+			},
+		},
+		{
+			name: "Tab2_Log",
+			tab:  2,
+			wantContains: []string{
+				"pgup/pgdn",
+				"j/k: スクロール",
+				"/: 検索",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewAppModel(nil, "")
+			m.state = StateViewer
+			m.session = claude.SessionInfo{SessionID: "test", Project: "/test"}
+			m.width = 120
+			m.height = 40
+			m.tabs.SetActive(tt.tab)
+			if tt.tab == 1 {
+				m.agentView.mode = tt.agentMode
+			}
+
+			help := m.footerHelp()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(help, want) {
+					t.Errorf("footerHelp() = %q, want to contain %q", help, want)
+				}
+			}
+		})
+	}
+}
+
 func TestAppModel_ShiftArrowDelegatedToConversationView(t *testing.T) {
 	m := NewAppModel(nil, "")
 	m.state = StateViewer

--- a/internal/tui/conversationview.go
+++ b/internal/tui/conversationview.go
@@ -115,6 +115,14 @@ func (m ConversationViewModel) Update(msg tea.KeyMsg) (ConversationViewModel, bo
 	case "down", "j":
 		m.scrollOffset++
 		m.clampScroll()
+	case "pgdown":
+		m.scrollOffset += m.viewHeight()
+		m.clampScroll()
+	case "pgup":
+		m.scrollOffset -= m.viewHeight()
+		if m.scrollOffset < 0 {
+			m.scrollOffset = 0
+		}
 	}
 
 	return m, true

--- a/internal/tui/conversationview_test.go
+++ b/internal/tui/conversationview_test.go
@@ -32,12 +32,14 @@ func testEntries() []claude.ConversationEntry {
 }
 
 var (
-	escKey   = tea.KeyMsg{Type: tea.KeyEsc}
-	jKey     = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}
-	kKey     = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")}
+	escKey        = tea.KeyMsg{Type: tea.KeyEsc}
+	jKey          = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")}
+	kKey          = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")}
 	enterKey      = tea.KeyMsg{Type: tea.KeyEnter}
 	shiftLeftKey  = tea.KeyMsg{Type: tea.KeyShiftLeft}
 	shiftRightKey = tea.KeyMsg{Type: tea.KeyShiftRight}
+	pgUpKey       = tea.KeyMsg{Type: tea.KeyPgUp}
+	pgDownKey     = tea.KeyMsg{Type: tea.KeyPgDown}
 )
 
 func TestConversationView_EmptyState(t *testing.T) {
@@ -409,6 +411,127 @@ func TestConversationView_FilterCursorNavigation(t *testing.T) {
 	m, _ = m.Update(shiftLeftKey)
 	if m.filterCursor != 0 {
 		t.Errorf("filterCursor should stay at 0, got %d", m.filterCursor)
+	}
+}
+
+func TestConversationView_PageDown(t *testing.T) {
+	// Given: a conversation view with enough content to scroll
+	// viewHeight = height(30) - 3 = 27
+	longText := strings.Repeat("Line of text.\n", 100)
+	entries := []claude.ConversationEntry{
+		{Type: claude.EntryTypeAssistant, Content: []claude.ContentBlock{{Type: "text", Text: longText}}},
+	}
+	m := newTestConversationView(entries)
+
+	// Scroll to top first (SetData scrolls to bottom)
+	m.scrollOffset = 0
+
+	// When: pgdown is pressed
+	m, handled := m.Update(pgDownKey)
+
+	// Then: scrollOffset increases by viewHeight (27)
+	if !handled {
+		t.Error("pgdown key should be handled")
+	}
+	if m.scrollOffset != 27 {
+		t.Errorf("after pgdown, scrollOffset = %d, want 27", m.scrollOffset)
+	}
+}
+
+func TestConversationView_PageUp(t *testing.T) {
+	// Given: a conversation view scrolled down
+	longText := strings.Repeat("Line of text.\n", 100)
+	entries := []claude.ConversationEntry{
+		{Type: claude.EntryTypeAssistant, Content: []claude.ContentBlock{{Type: "text", Text: longText}}},
+	}
+	m := newTestConversationView(entries)
+
+	// Start at a known scroll position
+	m.scrollOffset = 50
+
+	// When: pgup is pressed
+	m, handled := m.Update(pgUpKey)
+
+	// Then: scrollOffset decreases by viewHeight (27)
+	if !handled {
+		t.Error("pgup key should be handled")
+	}
+	if m.scrollOffset != 23 {
+		t.Errorf("after pgup, scrollOffset = %d, want 23", m.scrollOffset)
+	}
+}
+
+func TestConversationView_PageDown_ClampsAtBottom(t *testing.T) {
+	// Given: a conversation view near the bottom
+	longText := strings.Repeat("Line of text.\n", 50)
+	entries := []claude.ConversationEntry{
+		{Type: claude.EntryTypeAssistant, Content: []claude.ContentBlock{{Type: "text", Text: longText}}},
+	}
+	m := newTestConversationView(entries)
+
+	// Set scrollOffset near the end (will be clamped by clampScroll)
+	m.scrollOffset = 0
+
+	// Press pgdown multiple times to reach the end
+	for i := 0; i < 10; i++ {
+		m, _ = m.Update(pgDownKey)
+	}
+
+	// Then: scrollOffset should be clamped to maxScroll, not exceed it
+	maxScroll := m.maxScroll()
+	if m.scrollOffset > maxScroll {
+		t.Errorf("scrollOffset = %d exceeds maxScroll = %d", m.scrollOffset, maxScroll)
+	}
+	if m.scrollOffset != maxScroll {
+		t.Errorf("scrollOffset = %d, want maxScroll = %d", m.scrollOffset, maxScroll)
+	}
+}
+
+func TestConversationView_PageUp_ClampsAtTop(t *testing.T) {
+	// Given: a conversation view near the top
+	longText := strings.Repeat("Line of text.\n", 50)
+	entries := []claude.ConversationEntry{
+		{Type: claude.EntryTypeAssistant, Content: []claude.ContentBlock{{Type: "text", Text: longText}}},
+	}
+	m := newTestConversationView(entries)
+	m.scrollOffset = 5
+
+	// When: pgup is pressed (viewHeight=27, offset=5 → would go to -22)
+	m, _ = m.Update(pgUpKey)
+
+	// Then: scrollOffset is clamped at 0
+	if m.scrollOffset != 0 {
+		t.Errorf("after pgup from offset 5, scrollOffset = %d, want 0", m.scrollOffset)
+	}
+}
+
+func TestConversationView_PageScroll_FewerLinesThanPageSize(t *testing.T) {
+	// Given: a conversation view with fewer lines than viewHeight
+	entries := []claude.ConversationEntry{
+		{Type: claude.EntryTypeAssistant, Content: []claude.ContentBlock{{Type: "text", Text: "Short text"}}},
+	}
+	m := newTestConversationView(entries)
+
+	// When: pgdown is pressed
+	m, handled := m.Update(pgDownKey)
+
+	// Then: scrollOffset stays at 0 (maxScroll is 0)
+	if !handled {
+		t.Error("pgdown key should be handled")
+	}
+	if m.scrollOffset != 0 {
+		t.Errorf("pgdown with few items, scrollOffset = %d, want 0", m.scrollOffset)
+	}
+
+	// When: pgup is pressed
+	m, handled = m.Update(pgUpKey)
+
+	// Then: scrollOffset stays at 0
+	if !handled {
+		t.Error("pgup key should be handled")
+	}
+	if m.scrollOffset != 0 {
+		t.Errorf("pgup with few items, scrollOffset = %d, want 0", m.scrollOffset)
 	}
 }
 

--- a/internal/tui/logview.go
+++ b/internal/tui/logview.go
@@ -76,6 +76,15 @@ func (m *LogViewModel) SetSize(width, height int) {
 	m.clampScroll()
 }
 
+// pageSize returns the number of lines per page scroll.
+func (m LogViewModel) pageSize() int {
+	ps := m.height - 4
+	if ps < 1 {
+		ps = 1
+	}
+	return ps
+}
+
 // EntryCount returns the number of stored entries.
 func (m LogViewModel) EntryCount() int {
 	return len(m.entries)
@@ -147,18 +156,26 @@ func (m LogViewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.searching = true
 			m.searchInput.Focus()
 			return m, m.searchInput.Cursor.BlinkCmd()
-		default:
-			switch msg.String() {
-			case "up", "k":
-				if m.scrollOffset > 0 {
-					m.scrollOffset--
+			default:
+				switch msg.String() {
+				case "up", "k":
+					if m.scrollOffset > 0 {
+						m.scrollOffset--
+					}
+				case "down", "j":
+					m.scrollOffset++
+					m.clampScroll()
+				case "pgdown":
+					m.scrollOffset += m.pageSize()
+					m.clampScroll()
+				case "pgup":
+					m.scrollOffset -= m.pageSize()
+					if m.scrollOffset < 0 {
+						m.scrollOffset = 0
+					}
 				}
-			case "down", "j":
-				m.scrollOffset++
-				m.clampScroll()
 			}
 		}
-	}
 	return m, nil
 }
 

--- a/internal/tui/logview_test.go
+++ b/internal/tui/logview_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -309,6 +310,136 @@ func TestLogView_FilterCursorNavigation(t *testing.T) {
 	m = newModel.(LogViewModel)
 	if m.filterCursor != 0 {
 		t.Errorf("filterCursor should stay at 0, got %d", m.filterCursor)
+	}
+}
+
+// pgUpKey, pgDownKey are declared in conversationview_test.go (same package)
+
+func TestLogView_PageDown(t *testing.T) {
+	m := NewLogViewModel()
+	m.SetSize(80, 24) // pageSize = height(24) - 4 = 20
+
+	// Given: 50 ERROR entries, scrolled to top
+	entries := make([]claude.LogEntry, 50)
+	for i := range entries {
+		entries[i] = makeLogEntry(claude.LevelERROR, fmt.Sprintf("error line %d", i))
+	}
+	newModel, _ := m.Update(watcher.LogEntriesMsg{Entries: entries, Initial: true})
+	m = newModel.(LogViewModel)
+	m.scrollOffset = 0
+
+	// When: pgdown is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = newModel.(LogViewModel)
+
+	// Then: scrollOffset increases by pageSize (20)
+	if m.scrollOffset != 20 {
+		t.Errorf("after pgdown, scrollOffset = %d, want 20", m.scrollOffset)
+	}
+}
+
+func TestLogView_PageUp(t *testing.T) {
+	m := NewLogViewModel()
+	m.SetSize(80, 24) // pageSize = height(24) - 4 = 20
+
+	// Given: 50 ERROR entries, scrollOffset at 30
+	entries := make([]claude.LogEntry, 50)
+	for i := range entries {
+		entries[i] = makeLogEntry(claude.LevelERROR, fmt.Sprintf("error line %d", i))
+	}
+	newModel, _ := m.Update(watcher.LogEntriesMsg{Entries: entries, Initial: true})
+	m = newModel.(LogViewModel)
+	m.scrollOffset = 30
+
+	// When: pgup is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = newModel.(LogViewModel)
+
+	// Then: scrollOffset decreases by pageSize (20)
+	if m.scrollOffset != 10 {
+		t.Errorf("after pgup, scrollOffset = %d, want 10", m.scrollOffset)
+	}
+}
+
+func TestLogView_PageDown_ClampsAtBottom(t *testing.T) {
+	m := NewLogViewModel()
+	m.SetSize(80, 24) // pageSize = 20
+
+	// Given: 50 ERROR entries, scrollOffset near the end
+	entries := make([]claude.LogEntry, 50)
+	for i := range entries {
+		entries[i] = makeLogEntry(claude.LevelERROR, fmt.Sprintf("error line %d", i))
+	}
+	newModel, _ := m.Update(watcher.LogEntriesMsg{Entries: entries, Initial: true})
+	m = newModel.(LogViewModel)
+	maxScroll := m.maxScroll()
+	if maxScroll == 0 {
+		t.Fatal("expected maxScroll > 0 with 50 entries")
+	}
+	m.scrollOffset = maxScroll - 1
+
+	// When: pgdown is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = newModel.(LogViewModel)
+
+	// Then: scrollOffset is clamped to maxScroll
+	if m.scrollOffset != maxScroll {
+		t.Errorf("scrollOffset = %d, want maxScroll = %d", m.scrollOffset, maxScroll)
+	}
+}
+
+func TestLogView_PageUp_ClampsAtTop(t *testing.T) {
+	m := NewLogViewModel()
+	m.SetSize(80, 24) // pageSize = 20
+
+	// Given: 50 ERROR entries, scrollOffset at 5
+	entries := make([]claude.LogEntry, 50)
+	for i := range entries {
+		entries[i] = makeLogEntry(claude.LevelERROR, fmt.Sprintf("error line %d", i))
+	}
+	newModel, _ := m.Update(watcher.LogEntriesMsg{Entries: entries, Initial: true})
+	m = newModel.(LogViewModel)
+	m.scrollOffset = 5
+
+	// When: pgup is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = newModel.(LogViewModel)
+
+	// Then: scrollOffset clamped to 0
+	if m.scrollOffset != 0 {
+		t.Errorf("after pgup near top, scrollOffset = %d, want 0", m.scrollOffset)
+	}
+}
+
+func TestLogView_PageScroll_FewerEntriesThanPageSize(t *testing.T) {
+	m := NewLogViewModel()
+	m.SetSize(80, 24) // pageSize = 20
+
+	// Given: only 5 ERROR entries (fewer than pageSize of 20)
+	entries := make([]claude.LogEntry, 5)
+	for i := range entries {
+		entries[i] = makeLogEntry(claude.LevelERROR, fmt.Sprintf("error line %d", i))
+	}
+	newModel, _ := m.Update(watcher.LogEntriesMsg{Entries: entries, Initial: true})
+	m = newModel.(LogViewModel)
+	m.scrollOffset = 0
+
+	// When: pgdown is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = newModel.(LogViewModel)
+
+	// Then: scrollOffset remains 0 because all lines fit
+	if m.scrollOffset != 0 {
+		t.Errorf("pgdown with few entries, scrollOffset = %d, want 0", m.scrollOffset)
+	}
+
+	// When: pgup is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = newModel.(LogViewModel)
+
+	// Then: scrollOffset remains 0
+	if m.scrollOffset != 0 {
+		t.Errorf("pgup with few entries, scrollOffset = %d, want 0", m.scrollOffset)
 	}
 }
 

--- a/internal/tui/taskview.go
+++ b/internal/tui/taskview.go
@@ -87,6 +87,18 @@ func (m TaskViewModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "enter":
 		m.showDetail = !m.showDetail
+	case "pgdown":
+		if len(m.tasks) > 0 {
+			m.selected += m.viewHeight()
+			if m.selected >= len(m.tasks) {
+				m.selected = len(m.tasks) - 1
+			}
+		}
+	case "pgup":
+		m.selected -= m.viewHeight()
+		if m.selected < 0 {
+			m.selected = 0
+		}
 	}
 	m = m.clampScroll()
 	return m, nil

--- a/internal/tui/taskview_test.go
+++ b/internal/tui/taskview_test.go
@@ -339,3 +339,165 @@ func TestTaskView_ScrollFollowsSelection(t *testing.T) {
 		t.Errorf("scrollOffset = %d, want 0", m.scrollOffset)
 	}
 }
+
+// pgUpKey, pgDownKey are declared in conversationview_test.go (same package)
+
+func TestTaskView_PageDown(t *testing.T) {
+	m := NewTaskViewModel()
+	m.SetSize(80, 7) // viewHeight = 7-2 = 5
+
+	// Given: 20 tasks, selected at 0
+	tasks := make([]claude.Task, 20)
+	for i := range tasks {
+		tasks[i] = claude.Task{
+			ID:      fmt.Sprintf("%d", i+1),
+			Subject: fmt.Sprintf("Task %d", i+1),
+			Status:  "pending",
+		}
+	}
+	newModel, _ := m.Update(watcher.TasksUpdatedMsg{Tasks: tasks})
+	m = newModel.(TaskViewModel)
+
+	// When: pgdown is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = newModel.(TaskViewModel)
+
+	// Then: selected moves by viewHeight (5)
+	if m.selected != 5 {
+		t.Errorf("after pgdown, selected = %d, want 5", m.selected)
+	}
+}
+
+func TestTaskView_PageUp(t *testing.T) {
+	m := NewTaskViewModel()
+	m.SetSize(80, 7) // viewHeight = 7-2 = 5
+
+	// Given: 20 tasks, selected at index 10
+	tasks := make([]claude.Task, 20)
+	for i := range tasks {
+		tasks[i] = claude.Task{
+			ID:      fmt.Sprintf("%d", i+1),
+			Subject: fmt.Sprintf("Task %d", i+1),
+			Status:  "pending",
+		}
+	}
+	newModel, _ := m.Update(watcher.TasksUpdatedMsg{Tasks: tasks})
+	m = newModel.(TaskViewModel)
+
+	// Move to index 10
+	for i := 0; i < 10; i++ {
+		newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = newModel.(TaskViewModel)
+	}
+	if m.selected != 10 {
+		t.Fatalf("setup: selected = %d, want 10", m.selected)
+	}
+
+	// When: pgup is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = newModel.(TaskViewModel)
+
+	// Then: selected moves up by viewHeight (5)
+	if m.selected != 5 {
+		t.Errorf("after pgup, selected = %d, want 5", m.selected)
+	}
+}
+
+func TestTaskView_PageDown_ClampsAtEnd(t *testing.T) {
+	m := NewTaskViewModel()
+	m.SetSize(80, 7) // viewHeight = 7-2 = 5
+
+	// Given: 8 tasks, selected at index 5
+	tasks := make([]claude.Task, 8)
+	for i := range tasks {
+		tasks[i] = claude.Task{
+			ID:      fmt.Sprintf("%d", i+1),
+			Subject: fmt.Sprintf("Task %d", i+1),
+			Status:  "pending",
+		}
+	}
+	newModel, _ := m.Update(watcher.TasksUpdatedMsg{Tasks: tasks})
+	m = newModel.(TaskViewModel)
+
+	// Move to index 5
+	for i := 0; i < 5; i++ {
+		newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = newModel.(TaskViewModel)
+	}
+
+	// When: pgdown is pressed (5 + 5 = 10, but max is 7)
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = newModel.(TaskViewModel)
+
+	// Then: selected is clamped to last item (index 7)
+	if m.selected != 7 {
+		t.Errorf("after pgdown at near-end, selected = %d, want 7", m.selected)
+	}
+}
+
+func TestTaskView_PageUp_ClampsAtStart(t *testing.T) {
+	m := NewTaskViewModel()
+	m.SetSize(80, 7) // viewHeight = 7-2 = 5
+
+	// Given: 20 tasks, selected at index 3
+	tasks := make([]claude.Task, 20)
+	for i := range tasks {
+		tasks[i] = claude.Task{
+			ID:      fmt.Sprintf("%d", i+1),
+			Subject: fmt.Sprintf("Task %d", i+1),
+			Status:  "pending",
+		}
+	}
+	newModel, _ := m.Update(watcher.TasksUpdatedMsg{Tasks: tasks})
+	m = newModel.(TaskViewModel)
+
+	// Move to index 3
+	for i := 0; i < 3; i++ {
+		newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+		m = newModel.(TaskViewModel)
+	}
+
+	// When: pgup is pressed (3 - 5 = -2, should clamp to 0)
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = newModel.(TaskViewModel)
+
+	// Then: selected is clamped to 0
+	if m.selected != 0 {
+		t.Errorf("after pgup near start, selected = %d, want 0", m.selected)
+	}
+}
+
+func TestTaskView_PageScroll_FewerTasksThanPageSize(t *testing.T) {
+	m := NewTaskViewModel()
+	m.SetSize(80, 12) // viewHeight = 12-2 = 10
+
+	// Given: only 3 tasks (fewer than page size of 10)
+	tasks := make([]claude.Task, 3)
+	for i := range tasks {
+		tasks[i] = claude.Task{
+			ID:      fmt.Sprintf("%d", i+1),
+			Subject: fmt.Sprintf("Task %d", i+1),
+			Status:  "pending",
+		}
+	}
+	newModel, _ := m.Update(watcher.TasksUpdatedMsg{Tasks: tasks})
+	m = newModel.(TaskViewModel)
+
+	// When: pgdown is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	m = newModel.(TaskViewModel)
+
+	// Then: selected moves to last task (index 2)
+	if m.selected != 2 {
+		t.Errorf("pgdown with few tasks, selected = %d, want 2", m.selected)
+	}
+
+	// When: pgup is pressed
+	newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyPgUp})
+	m = newModel.(TaskViewModel)
+
+	// Then: selected moves back to 0
+	if m.selected != 0 {
+		t.Errorf("pgup with few tasks, selected = %d, want 0", m.selected)
+	}
+}


### PR DESCRIPTION
## Summary
- 全ビュー（Tasks/Agents/Log/Conversation）にPgUp/PgDnページスクロールを追加
- 各ビューのスクロール処理にページ単位の移動ロジックを実装
- ページスクロールのテストを追加

## Test plan
- [ ] `go test ./internal/tui/...` でテストが通ること
- [ ] PgUp/PgDnキーで各ビューがページ単位でスクロールすること